### PR TITLE
Improvements to split packages

### DIFF
--- a/src/SplitPackages/Program.cs
+++ b/src/SplitPackages/Program.cs
@@ -87,7 +87,7 @@ namespace SplitPackages
                 CommandOptionType.NoValue);
 
             var warningsOnly = app.Option(
-                "--warningsonly",
+                "--quiet",
                 "Avoids printing to the output anything other than warnings or errors",
                 CommandOptionType.NoValue);
 
@@ -326,7 +326,8 @@ namespace SplitPackages
 
             return new List<PackageItem>
             {
-                new PackageItem {
+                new PackageItem
+                {
                     OriginPath = packageFromSource.OriginPath,
                     Name = packageFromSource.Name,
                     DestinationFolderName = destinationFolderName,
@@ -338,7 +339,9 @@ namespace SplitPackages
 
         private static IList<PackageItem> ExpandPackagesFromPattern(
             string sourceFolder,
-            IList<PackageItem> packagesFromSource, string pattern, string destinationFolderName)
+            IList<PackageItem> packagesFromSource,
+            string pattern,
+            string destinationFolderName)
         {
             return Directory.EnumerateFiles(sourceFolder, pattern)
                 .Select(fp =>

--- a/src/SplitPackages/Program.cs
+++ b/src/SplitPackages/Program.cs
@@ -259,7 +259,9 @@ namespace SplitPackages
         private IList<PackageItem> GetPackagesFromCsvFile(string csvFile)
         {
             var lines = File.ReadAllLines(csvFile).Skip(1); // Skip file header
-            var parsedLines = lines.Select(l => l.Split(','));
+            var parsedLines = lines
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .Select(l => l.Split(','));
 
             // Order the entries so that most specific entries come first.
             return parsedLines

--- a/src/SplitPackages/project.json
+++ b/src/SplitPackages/project.json
@@ -12,7 +12,8 @@
         "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
         "Microsoft.Extensions.Logging": "1.0.0-*",
         "Microsoft.Extensions.Logging.Console": "1.0.0-*",
-        "Newtonsoft.Json": "8.0.2"
+        "Newtonsoft.Json": "8.0.2",
+        "NuGet.Client": "3.4.0-beta-595"
     },
     "frameworks": {
         "net451": {

--- a/src/SplitPackages/project.json
+++ b/src/SplitPackages/project.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
         "Microsoft.Extensions.Logging": "1.0.0-*",
-        "Microsoft.Extensions.Logging.Console": "1.0.0-*"
+        "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+        "Newtonsoft.Json": "8.0.2"
     },
     "frameworks": {
         "net451": {

--- a/src/SplitPackages/project.json
+++ b/src/SplitPackages/project.json
@@ -13,7 +13,7 @@
         "Microsoft.Extensions.Logging": "1.0.0-*",
         "Microsoft.Extensions.Logging.Console": "1.0.0-*",
         "Newtonsoft.Json": "8.0.2",
-        "NuGet.Client": "3.4.0-beta-595"
+        "NuGet.Client": "3.4.0-*"
     },
     "frameworks": {
         "net451": {


### PR DESCRIPTION
* Fix bug in whatif option not being honored.
* Added support for generating project.json files that allow restoring from
  the destination folders.
* Added an option to treat warnings as errors and fail early.
* Added an option to print only warning and error messages only.
