### PR TITLE
Add rule for checking CommitHash

### DIFF
--- a/src/NuGetPackageVerifier/CompositeRules/AdxVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/AdxVerificationCompositeRule.cs
@@ -12,6 +12,7 @@ namespace NuGetPackageVerifier.Rules
     {
         IPackageVerifierRule[] _rules = new IPackageVerifierRule[]
         {
+            new AssemblyHasCommitHashAttributeRule(),
             new AssemblyHasCompanyAttributeRule(),
             new AssemblyHasCopyrightAttributeRule(),
             new AssemblyHasCorrectJsonNetVersionRule(),

--- a/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
@@ -12,6 +12,7 @@ namespace NuGetPackageVerifier.Rules
     {
         IPackageVerifierRule[] _rules = new IPackageVerifierRule[]
         {
+            new AssemblyHasCommitHashAttributeRule(),
             new AssemblyHasCompanyAttributeRule(),
             new AssemblyHasCopyrightAttributeRule(),
             new AssemblyHasCorrectJsonNetVersionRule(),

--- a/src/NuGetPackageVerifier/PackageIssueFactory.cs
+++ b/src/NuGetPackageVerifier/PackageIssueFactory.cs
@@ -19,6 +19,17 @@ namespace NuGetPackageVerifier
                 MyPackageIssueLevel.Error);
         }
 
+        public static PackageVerifierIssue AssemblyMissingHashAttribute(string assemblyPath)
+        {
+            return new PackageVerifierIssue(
+                "ASSEMBLY_COMMIT_HASH",
+                assemblyPath,
+                string.Format(
+                    @"The managed assembly '{0}' in this package is missing the '[assembly: AssemblyMetadata(""CommitHash"", ""<text>"")]' attribute.",
+                    assemblyPath),
+                MyPackageIssueLevel.Error);
+        }
+
         public static PackageVerifierIssue AssemblyMissingNeutralResourcesLanguageAttribute(string assemblyPath)
         {
             return new PackageVerifierIssue(

--- a/src/NuGetPackageVerifier/Program.cs
+++ b/src/NuGetPackageVerifier/Program.cs
@@ -68,6 +68,7 @@ namespace NuGetPackageVerifier
 
             // TODO: Look this up using reflection or something
             var allRules = new IPackageVerifierRule[] {
+                new AssemblyHasCommitHashAttributeRule(),
                 new AssemblyHasCompanyAttributeRule(),
                 new AssemblyHasCopyrightAttributeRule(),
                 new AssemblyHasCorrectJsonNetVersionRule(),

--- a/src/NuGetPackageVerifier/Rules/AssemblyHasCommitHashAttributeRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyHasCommitHashAttributeRule.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class AssemblyHasCommitHashAttributeRule : AssemblyHasAttributeRuleBase
+    {
+        public override IEnumerable<PackageVerifierIssue> ValidateAttribute(
+            string currentFilePath,
+            Collection<CustomAttribute> assemblyAttributes)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(currentFilePath);
+            var isSourcesPackage = fileName.EndsWith(".Sources", System.StringComparison.OrdinalIgnoreCase);
+            if (!isSourcesPackage && !HasCommitHashInMetadataAttribute(assemblyAttributes))
+            {
+                yield return PackageIssueFactory.AssemblyMissingHashAttribute(currentFilePath);
+            }
+        }
+
+        private static bool HasCommitHashInMetadataAttribute(Collection<CustomAttribute> assemblyAttributes)
+        {
+            var hashAttribute = assemblyAttributes
+                .SingleOrDefault(a =>
+                    a.AttributeType.FullName == typeof(AssemblyMetadataAttribute).FullName
+                    && a.ConstructorArguments.Count == 2
+                    && a.ConstructorArguments[0].Value as string == "CommitHash"
+                    && !string.IsNullOrEmpty(a.ConstructorArguments[1].Value as string));
+
+            return hashAttribute != null;
+        }
+    }
+}


### PR DESCRIPTION
Adds a rule for checking the CommitHash attribute. Fixes #34.

CC @Eilon @ajaybhargavb @victorhurdugaci 