### PR TITLE
Use case-insensitive comparison when checking the assembly public key token

### DIFF
--- a/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
@@ -61,7 +61,7 @@ namespace NuGetPackageVerifier.Rules
 
                                 var testAssembly = AssemblyName.GetAssemblyName(assemblyPath);
                                 var tokenHexString = BitConverter.ToString(testAssembly.GetPublicKeyToken()).Replace("-", "");
-                                if (_publicKeyToken.Equals(tokenHexString))
+                                if (_publicKeyToken.Equals(tokenHexString, StringComparison.OrdinalIgnoreCase))
                                 {
                                     hasCorrectPublicKeyToken = true;
                                 }


### PR DESCRIPTION
This is a little usability improvement, especially considering `sn.exe -T` outputs a lowercase hex string.

@ajaybhargavb 